### PR TITLE
Add multiple print example to Exploring Python

### DIFF
--- a/content/04_exploring_python/exploring_python.ipynb
+++ b/content/04_exploring_python/exploring_python.ipynb
@@ -150,9 +150,9 @@
     "Now that we have called our first python command and gotten our first error message, let's break down what we just did.\n",
     "\n",
     "###  Calling Python Functions\n",
-    "When we typed print, python interpreted that as a *function*. Functions take input and do things with it. They may in some cases give us back a result. The way they take input is based on what we put inside the parentheses after we call the function.\n",
+    "When we typed print, python interpreted that as a *function*. Functions take input and do things with it. They may in some cases give us back a result. The way they take input is based on what we put inside the parentheses after we call the function. Variables we pass to a function when we call it are known as the *arguments* of that function.\n",
     "\n",
-    "What about the \"Hello World!\" part? When we put that text inside quotation marks, we told python to create a new string object. String objects hold text within python. We'll consider them in much more depth shortly.\n",
+    "So in our example \"Hello World!\" would be an argument we are passing to the print function. Why is \"Hello World!\" in quotation marks? When we put that text inside quotation marks, we told python to create a new string object. String objects hold text within python. We'll consider them in much more depth shortly.\n",
     "\n",
     "We can print a number instead of \"Hello world!\" as follows: "
    ]
@@ -178,7 +178,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We used the same function -- print -- but now changed the input we gave it to a number. This caused the number to be printed to the screen. The input that we have given the print function inside its parentheses (42 or \"Hello World!\") is called a **positional argument** to that function. The whole thing - the function plus any arguments inside parentheses - is called the **function call**. \n",
+    "We used the same function -- print -- but now changed the argument we gave it to a number. This caused the number to be printed to the screen. The input that we have given the print function inside its parentheses (42 or \"Hello World!\") is called a **positional argument** to that function. \n",
+    "\n",
+    "The whole thing - the function plus any arguments inside parentheses - is called the **function call**. \n",
     "\n",
     "print() is just one of many [built in functions](https://docs.python.org/3/library/functions.html) that come with python. \n",
     "\n",
@@ -389,14 +391,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Functions with more than one argument and getting help.\n",
+    "#### Functions with more than one argument\n",
     "\n",
-    "Many python functions take more than one argument. For example, when you want to round a number, the round() function requires that you tell it both the number, and how many places you want to round it to. In such cases, you pass in the arguments to your function separated by commas. The code below rounds the value of pi to two decimal places:"
+    "Many python functions take more than one positional argument. In such cases, you pass in the arguments to your function separated by commas. We have already encountered one example of a function that can take more than one argument - though we haven't yet taken advantage of that capability. \n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "My favorite number is  42\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"My favorite number is \", 42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When print is called with more than one positional argument, it attempts to print each to the screen in order. Other functions assign special meaning to each argument based on the order they are passed in. For example, when you want to round a number, the round() function requires that you tell it the number as the first positional argument, and how many places you want to round it to as the second. The code below rounds the value of pi to two decimal places:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +470,46 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
+    "**Quick check of keyword argument syntax**: let's confirm by experimentation that keyword arguments must follow positional arguments. To test this, let's try modifying our command to round pi so the keyword argument goes first. If it's true that keyword arguments must go last then we should get an error message (if you tried intentionally getting some errors by modifying our print(\"Hello World!\") command, you may wish to stop and consider what kind of error message you expect to get here)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "positional argument follows keyword argument (<ipython-input-8-883fd06d6dc3>, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-8-883fd06d6dc3>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    pi_approx = round(ndigits=2,pi)\u001b[0m\n\u001b[0m                               ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m positional argument follows keyword argument\n"
+     ]
+    }
+   ],
+   "source": [
+    "pi_approx = round(ndigits=2,pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above confirms that our understanding of the rule about how to pass keyword arguments is correct."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Getting help\n",
+    "\n",
     "The above example only works because I knew that the name of the keyword argument that the round function requires is ndigits. How did I know that? There are usually two ways to figure this out: \n",
     "1. Google the function. In this case I knew what the ndigits variable was called by reading the help text for the function in the python documentation [here](https://docs.python.org/3.3/library/functions.html)\n",
     "2. Call the **help()** function on the function within python to look up what keyword arguments it accepts. Below is an example of how we might look up help for the **round()** function"


### PR DESCRIPTION
Cleaned up examples, added an example of printing multiple messages. Added a second intentional exploration of error messages to confirm syntax rules about keyword argument position.